### PR TITLE
Add ability to configure output destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/README.MD
+++ b/README.MD
@@ -22,6 +22,18 @@ module.exports = {
 };
 ```
 
+or
+
+```javascript
+{
+  resolve: "gatsby-plugin-extract-schema",
+    options: {
+      dest: `${__dirname}/path/to/schema.json`,
+    },
+  },
+}
+```
+
 ## Check queries against schema
 
 ### Add `.eslintrc.js` to the project root

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,7 +2,7 @@ const write = require("write");
 const path = require("path");
 const { introspectionQuery, graphql } = require("gatsby/graphql");
 
-const snapshotLocation = path.resolve(process.cwd(), "schema.json");
+const defaultLocation = path.resolve(process.cwd(), "schema.json");
 
 exports.onPostBootstrap = ({ store }, options) => {
   const dest = options.dest || snapshotLocation;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,20 +1,22 @@
-const fs = require("fs");
+const write = require("write");
 const path = require("path");
 const { introspectionQuery, graphql } = require("gatsby/graphql");
 
 const snapshotLocation = path.resolve(process.cwd(), "schema.json");
 
-exports.onPostBootstrap = ({ store }) =>
+exports.onPostBootstrap = ({ store }, options) => {
+  const dest = options.dest || snapshotLocation;
   new Promise((resolve, reject) => {
     const { schema } = store.getState();
     graphql(schema, introspectionQuery)
-      .then(res => fs.writeFileSync(snapshotLocation, JSON.stringify(res.data)))
+      .then(res => write.sync(dest, JSON.stringify(res.data)))
       .then(() => {
-        console.log("Wrote schema");
+        console.log("[gatsby-plugin-extract-schema] Wrote schema");
         resolve();
       })
       .catch(e => {
-        console.log("Failed to write schema: ", e);
+        console.error("[gatsby-plugin-extract-schema] Failed to write schema: ", e);
         reject();
       });
   });
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,7 +5,7 @@ const { introspectionQuery, graphql } = require("gatsby/graphql");
 const defaultLocation = path.resolve(process.cwd(), "schema.json");
 
 exports.onPostBootstrap = ({ store }, options) => {
-  const dest = options.dest || snapshotLocation;
+  const dest = options.dest || defaultLocation;
   new Promise((resolve, reject) => {
     const { schema } = store.getState();
     graphql(schema, introspectionQuery)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "gatsby-plugin-extract-schema",
+  "version": "0.0.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
     "babel-eslint": ">8.0.0",
     "eslint": ">4.0.0",
     "eslint-plugin-graphql": ">2.0.0"
+  },
+  "devDependencies": {},
+  "dependencies": {
+    "write": "^1.0.3"
   }
 }


### PR DESCRIPTION
Adds the ability to configure the output location of the schema:

```js
{
  resolve: "gatsby-plugin-extract-schema",
    options: {
      dest: "./src/schema.json",
    }
  }
}
```

as well as slightly better log output so that this plugin can be identified in the terminal:

```sh
[gatsby-plugin-extract-schema] Wrote schema
```