### PR TITLE
Added option to nest schema under data property

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -29,10 +29,15 @@ or
   resolve: "gatsby-plugin-extract-schema",
     options: {
       dest: `${__dirname}/path/to/schema.json`,
+      // Output schema into {"data": {"__schema": ...}}
+      // instead of {"__schema": ...}.
+      nested: true,
     },
   },
 }
 ```
+
+Note: If the generated schema is not working for you, try enabling the "nested" option like in the example above.
 
 ## Check queries against schema
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,22 +1,25 @@
 const write = require("write");
 const path = require("path");
-const { introspectionQuery, graphql } = require("gatsby/graphql");
+const {introspectionQuery, graphql} = require("gatsby/graphql");
 
 const defaultLocation = path.resolve(process.cwd(), "schema.json");
 
-exports.onPostBootstrap = ({ store }, options) => {
-  const dest = options.dest || defaultLocation;
-  new Promise((resolve, reject) => {
-    const { schema } = store.getState();
-    graphql(schema, introspectionQuery)
-      .then(res => write.sync(dest, JSON.stringify(res.data)))
-      .then(() => {
-        console.log("[gatsby-plugin-extract-schema] Wrote schema");
-        resolve();
-      })
-      .catch(e => {
-        console.error("[gatsby-plugin-extract-schema] Failed to write schema: ", e);
-        reject();
-      });
-  });
-}
+exports.onPostBootstrap = ({store}, options) => {
+    const dest = options.dest || defaultLocation;
+    new Promise((resolve, reject) => {
+        const {schema} = store.getState();
+        graphql(schema, introspectionQuery)
+            .then(res => {
+                const content = options.nested ? {data: res.data} : res.data;
+                write.sync(dest, JSON.stringify(content));
+            })
+            .then(() => {
+                console.log("[gatsby-plugin-extract-schema] Wrote schema");
+                resolve();
+            })
+            .catch(e => {
+                console.error("[gatsby-plugin-extract-schema] Failed to write schema: ", e);
+                reject();
+            });
+    });
+};


### PR DESCRIPTION
Some implementations using the generated schema do not work unless the schema is nested under the "data" attribute.
For example, the JS GraphQL IntelliJ Plugin for WebStorm, issue https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/issues/242#issuecomment-488014279.