### PR TITLE
Allow gatsby 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/NickyMeuleman/gatsby-plugin-extract-schema#readme",
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "write": "^2.0.0"


### PR DESCRIPTION
Just silences the warning. I've been running it on plugins.jenkins.io for like a week or two now without issue.

fixes #9